### PR TITLE
:bug: fix: invisible navbar on /contact desktop mode

### DIFF
--- a/src/app/contact/index.scss
+++ b/src/app/contact/index.scss
@@ -13,7 +13,7 @@
     height: 70px;
   }
 }
-.hidden {
+.hiddenspinner {
   display: none;
 }
 .spinner {

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -14,7 +14,7 @@ export default function Contact() {
   const [copy, setCopy] = useState(false);
   const [errMsg, setErrMsg] = useState('');
   const [success, setSuccess] = useState(false);
-  const [classState, setClassState] = useState('hidden spinner');
+  const [classState, setClassSpinner] = useState('hiddenspinner spinner');
   useEffect(() => {
     if (userRef.current) {
       userRef.current.focus();
@@ -26,7 +26,7 @@ export default function Contact() {
   }, [email, first_name, last_name, subject, message, copy]);
 
   function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    setClassState('spinner');
+    setClassSpinner('spinner');
     e.preventDefault();
     console.log(email, first_name, last_name, subject, message, copy);
     axios({
@@ -47,7 +47,7 @@ export default function Contact() {
       .then((response) => {
         console.log(response);
         setSuccess(true);
-        setClassState('hidden spinner');
+        setClassSpinner('hiddenspinner spinner');
       })
       .catch((error) => {
         if (!error?.response) {


### PR DESCRIPTION
Bon... en gros hier soir en faisant le responsive tout était bon (j'ai push quand j'avais fini le mobile ...)
Mais je viens de me rendre compte que la Navbar avait *aussi* la class  hidden et par défaut (qui d'ailleurs fait l'inverse de cacher) du coup le CSS de la page contact rendait le header invisible en mode desktop uniquement vu que mon animation avait aussi `hidden`. J'ai changé le nom de la classe de l'animation sur le css de contact. 🤷

Petite PR